### PR TITLE
Release v2.0.1

### DIFF
--- a/.bumper.toml
+++ b/.bumper.toml
@@ -1,5 +1,5 @@
 [tool.bumper]
-current_version = "2.0.0"
+current_version = "2.0.1"
 versioning_type = "semver"
 
 [[tool.bumper.files]]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -55,6 +55,10 @@ ignore = [
     "D101",
     "D103",
 ]
+"tests/conftest.py" = [
+    "D101",
+    "D103",
+]
 
 [lint.flake8-bugbear]
 extend-immutable-calls = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<ma
 ## [v2.0.1]
 ### Changed
 * #9 Change expected CalVer format to `<YYYY>.<MM>.<MICRO>`
+* #10 Feedback is now provided on the command line if a bump target file receives no changes
+* Feedback is now provided on the command line for each file that receives a bump
 
 ## [v2.0.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<major>`.`<minor>`.`<patch>`)
 
+## [v2.0.1]
+### Changed
+* #9 Change expected CalVer format to `<YYYY>.<MM>.<MICRO>`
+
 ## [v2.0.0]
 ### Changed
 * #7 `versioning_type` is now a required configuration key for the `[tool.bumper]` table

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ search = 'version = "{current_version}"'
 #### CalVer
 ```toml
 [tool.bumper]
-current_version = "2025.01.0"
+current_version = "2025.1.0"
 versioning_type = "calver"
 
 [[tool.bumper.files]]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bumper
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sco1-bumper/2.0.0?logo=python&logoColor=FFD43B)](https://pypi.org/project/sco1-bumper/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sco1-bumper/2.0.1?logo=python&logoColor=FFD43B)](https://pypi.org/project/sco1-bumper/)
 [![PyPI](https://img.shields.io/pypi/v/sco1-bumper?logo=Python&logoColor=FFD43B)](https://pypi.org/project/sco1-bumper/)
 [![PyPI - License](https://img.shields.io/pypi/l/sco1-bumper?color=magenta)](https://github.com/sco1/bumper/blob/main/LICENSE)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/sco1/bumper/main.svg)](https://results.pre-commit.ci/latest/github/sco1/bumper/main)
@@ -12,7 +12,7 @@ Heavily inspired by [`bump2version`](https://github.com/c4urself/bump2version) a
 * [Semantic Versioning (SemVer)](https://semver.org/#semantic-versioning-200)
   * Assumes `<MAJOR>.<MINOR>.<PATCH>`
 * [Calendar Versioning (CalVer)](https://calver.org/)
-  * Assumes `<YYYY>.<0M>.<MICRO>`
+  * Assumes `<YYYY>.<MM>.<MICRO>`
 
 ## Installation
 Install from PyPi with your favorite `pip` invocation, e.g.:

--- a/bumper/bump.py
+++ b/bumper/bump.py
@@ -85,6 +85,10 @@ def bump_ver(
                 r.replace("{current_version}", str(next_version)),
             )
 
+        if new == old:
+            print(f"{target_file.name} - No changes.")
+            continue
+
         if dry_run:
             diff = difflib.unified_diff(
                 old.splitlines(), new.splitlines(), fromfile=target_file.name, n=0, lineterm=""
@@ -93,3 +97,4 @@ def bump_ver(
             print("\n".join(line.rstrip() for line in diff))
         else:
             target_file.write_text(new)
+            print(f"Bumped {target_file.name}")

--- a/bumper/config.py
+++ b/bumper/config.py
@@ -105,7 +105,7 @@ search = 'version = "{current_version}"'
 
 STARTER_CONFIG_CALVER = """\
 [tool.bumper]
-current_version = "2025.01.0"
+current_version = "2025.1.0"
 versioning_type = "calver"
 
 [[tool.bumper.files]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sco1-bumper"
-version = "2.0.0"
+version = "2.0.1"
 description = "Automatically increment the project's version number."
 license = "MIT"
 license-files = ["LICENSE"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+SAMPLE_README = """\
+# bumper
+[![PyPI - Python Version](https://some.url/sco1-bumper/0.1.0?logo=python)]
+
+Automatically increment the project's version number.
+
+```yaml
+repos:
+-   repo: https://github.com/sco1/brie-commit
+    rev: v0.1.0
+    hooks:
+    -   id: brie-commit
+```
+"""
+
+SAMPLE_PYPROJECT = """\
+[project]
+name = "sco1-bumper"
+version = "0.1.0"
+description = "Automatically increment the project's version number."
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"""
+
+
+@pytest.fixture
+def dummy_repo(tmp_path: Path) -> Path:
+    (tmp_path / "README.md").write_text(SAMPLE_README)
+    (tmp_path / "pyproject.toml").write_text(SAMPLE_PYPROJECT)
+
+    return tmp_path

--- a/tests/test_bump_calver.py
+++ b/tests/test_bump_calver.py
@@ -7,12 +7,12 @@ from packaging.version import Version
 from bumper.bump import BumpType, _build_new_version
 
 CALVER_TEST_CASES = (
-    (Version("2025.01.0"), dt.date(year=2025, month=1, day=1), Version("2025.01.1")),
-    (Version("2025.01"), dt.date(year=2025, month=1, day=1), Version("2025.01.1")),
+    (Version("2025.1.0"), dt.date(year=2025, month=1, day=1), Version("2025.1.1")),
+    (Version("2025.01"), dt.date(year=2025, month=1, day=1), Version("2025.1.1")),
     (Version("2025.10.0"), dt.date(year=2025, month=10, day=1), Version("2025.10.1")),
     (Version("2025.10"), dt.date(year=2025, month=10, day=1), Version("2025.10.1")),
-    (Version("2025.01.0"), dt.date(year=2025, month=2, day=1), Version("2025.02.0")),
-    (Version("2025.01.1"), dt.date(year=2025, month=2, day=1), Version("2025.02.0")),
+    (Version("2025.1.0"), dt.date(year=2025, month=2, day=1), Version("2025.2.0")),
+    (Version("2025.1.1"), dt.date(year=2025, month=2, day=1), Version("2025.2.0")),
     (Version("2025.10.0"), dt.date(year=2025, month=11, day=1), Version("2025.11.0")),
     (Version("2025.10.1"), dt.date(year=2025, month=11, day=1), Version("2025.11.0")),
 )

--- a/tests/test_bump_calver.py
+++ b/tests/test_bump_calver.py
@@ -8,7 +8,7 @@ from bumper.bump import BumpType, _build_new_version
 
 CALVER_TEST_CASES = (
     (Version("2025.1.0"), dt.date(year=2025, month=1, day=1), Version("2025.1.1")),
-    (Version("2025.01"), dt.date(year=2025, month=1, day=1), Version("2025.1.1")),
+    (Version("2025.1"), dt.date(year=2025, month=1, day=1), Version("2025.1.1")),
     (Version("2025.10.0"), dt.date(year=2025, month=10, day=1), Version("2025.10.1")),
     (Version("2025.10"), dt.date(year=2025, month=10, day=1), Version("2025.10.1")),
     (Version("2025.1.0"), dt.date(year=2025, month=2, day=1), Version("2025.2.0")),

--- a/tests/test_bump_feedback.py
+++ b/tests/test_bump_feedback.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+from bumper.bump import BumpType, BumperFile, bump_ver
+
+
+def test_empty_diff_feedback_single_file(dummy_repo: Path, capsys: pytest.CaptureFixture) -> None:
+    pyproject = dummy_repo / "pyproject.toml"
+    files = [
+        BumperFile(file=pyproject, search='version = "{current_version}"'),
+    ]
+
+    bump_ver(
+        current_version=Version("100.200.300"),
+        files=files,
+        bump_type=BumpType.MAJOR,
+        dry_run=False,
+    )
+
+    captured = capsys.readouterr()
+    assert "pyproject.toml - No changes" in captured.out
+
+
+def test_empty_diff_feedback_multi_file(dummy_repo: Path, capsys: pytest.CaptureFixture) -> None:
+    pyproject = dummy_repo / "pyproject.toml"
+    readme = dummy_repo / "README.md"
+    files = [
+        BumperFile(file=pyproject, search='version = "{current_version}"'),
+        BumperFile(file=readme, search="sco1-bumper/{current_version}"),
+    ]
+
+    bump_ver(
+        current_version=Version("100.200.300"),
+        files=files,
+        bump_type=BumpType.MAJOR,
+        dry_run=False,
+    )
+
+    captured = capsys.readouterr()
+    assert "pyproject.toml - No changes" in captured.out
+    assert "README.md - No changes" in captured.out
+
+
+def test_bumped_feedback_single_file(dummy_repo: Path, capsys: pytest.CaptureFixture) -> None:
+    pyproject = dummy_repo / "pyproject.toml"
+    files = [
+        BumperFile(file=pyproject, search='version = "{current_version}"'),
+    ]
+
+    bump_ver(
+        current_version=Version("0.1.0"),
+        files=files,
+        bump_type=BumpType.MAJOR,
+        dry_run=False,
+    )
+
+    captured = capsys.readouterr()
+    assert "Bumped pyproject.toml" in captured.out
+
+
+def test_bumped_feedback_multi_file(dummy_repo: Path, capsys: pytest.CaptureFixture) -> None:
+    pyproject = dummy_repo / "pyproject.toml"
+    readme = dummy_repo / "README.md"
+    files = [
+        BumperFile(file=pyproject, search='version = "{current_version}"'),
+        BumperFile(file=readme, search="sco1-bumper/{current_version}"),
+    ]
+
+    bump_ver(
+        current_version=Version("0.1.0"),
+        files=files,
+        bump_type=BumpType.MAJOR,
+        dry_run=False,
+    )
+
+    captured = capsys.readouterr()
+    assert "Bumped pyproject.toml" in captured.out
+    assert "Bumped README.md" in captured.out

--- a/tests/test_bump_semver.py
+++ b/tests/test_bump_semver.py
@@ -5,6 +5,7 @@ from packaging.version import Version
 
 from bumper.bump import BumpType, _build_new_version, _merge_bumpers, bump_ver
 from bumper.config import BumperFile
+from tests.conftest import SAMPLE_PYPROJECT, SAMPLE_README
 
 VERSION_BUILD_TEST_CASES = (
     (Version("0.0.1"), BumpType.MAJOR, Version("1.0.0")),
@@ -42,21 +43,6 @@ def test_merge_bumpers() -> None:
     assert _merge_bumpers(files) == truth_out
 
 
-SAMPLE_README = """\
-# bumper
-[![PyPI - Python Version](https://some.url/sco1-bumper/0.1.0?logo=python)]
-
-Automatically increment the project's version number.
-
-```yaml
-repos:
--   repo: https://github.com/sco1/brie-commit
-    rev: v0.1.0
-    hooks:
-    -   id: brie-commit
-```
-"""
-
 TRUTH_BUMPED_README = """\
 # bumper
 [![PyPI - Python Version](https://some.url/sco1-bumper/0.2.0?logo=python)]
@@ -72,17 +58,6 @@ repos:
 ```
 """
 
-SAMPLE_PYPROJECT = """\
-[project]
-name = "sco1-bumper"
-version = "0.1.0"
-description = "Automatically increment the project's version number."
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-"""
-
 TRUTH_BUMPED_PYPROJECT = """\
 [project]
 name = "sco1-bumper"
@@ -93,14 +68,6 @@ description = "Automatically increment the project's version number."
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 """
-
-
-@pytest.fixture
-def dummy_repo(tmp_path: Path) -> Path:
-    (tmp_path / "README.md").write_text(SAMPLE_README)
-    (tmp_path / "pyproject.toml").write_text(SAMPLE_PYPROJECT)
-
-    return tmp_path
 
 
 def test_bump_ver_single_replace(dummy_repo: Path) -> None:

--- a/tests/test_config_init.py
+++ b/tests/test_config_init.py
@@ -38,7 +38,7 @@ def test_write_default_config_existing_config_no_ignore_raises(tmp_path: Path) -
 
 STARTER_CONFIG_CALVER = """\
 [tool.bumper]
-current_version = "2025.01.0"
+current_version = "2025.1.0"
 versioning_type = "calver"
 
 [[tool.bumper.files]]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -92,7 +92,7 @@ TRUTH_SINGLE_REPLACE_SEMVER = (
     [BumperFile(file=Path("./pyproject.toml"), search='version = "{current_version}"')],
 )
 TRUTH_SINGLE_REPLACE_CALVER = (
-    version.Version("2025.01.0"),
+    version.Version("2025.1.0"),
     VersioningType.CALVER,
     [BumperFile(file=Path("./pyproject.toml"), search='version = "{current_version}"')],
 )
@@ -107,7 +107,7 @@ TRUTH_MULTI_REPLACE_SEMVER = (
     ],
 )
 TRUTH_MULTI_REPLACE_CALVER = (
-    version.Version("2025.01.0"),
+    version.Version("2025.1.0"),
     VersioningType.CALVER,
     [
         BumperFile(file=Path("./pyproject.toml"), search='version = "{current_version}"'),

--- a/tests/test_data/sample_config_calver.toml
+++ b/tests/test_data/sample_config_calver.toml
@@ -1,5 +1,5 @@
 [tool.bumper]
-current_version = "2025.01.0"
+current_version = "2025.1.0"
 versioning_type = "calver"
 
 [[tool.bumper.files]]

--- a/tests/test_data/sample_pyproject_calver.toml
+++ b/tests/test_data/sample_pyproject_calver.toml
@@ -1,10 +1,10 @@
 [project]
 name = "sco1-bumper"
-version = "2025.01.0"
+version = "2025.1.0"
 description = "Automatically increment the project's version number."
 
 [tool.bumper]
-current_version = "2025.01.0"
+current_version = "2025.1.0"
 versioning_type = "calver"
 
 [[tool.bumper.files]]


### PR DESCRIPTION
## [v2.0.1]
### Changed
* #9 Change expected CalVer format to `<YYYY>.<MM>.<MICRO>`
* #10 Feedback is now provided on the command line if a bump target file receives no changes
* Feedback is now provided on the command line for each file that receives a bump

Closes: #9
Closes: #10